### PR TITLE
Scene development -> Build and manage scenes:  Guide content (Add scenes to your project) + placeholders for images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -54,7 +54,7 @@ export default defineConfig({
               items: [
                 { label: 'System requirements', slug: 'guides/get-started/initial-setup/system-requirements' },
 				{ label: 'Sign up and login', slug: 'guides/get-started/initial-setup/sign-up-and-login' },
-				{ label: 'Create a Project', slug: 'guides/get-started/initial-setup/start-a-new-project' },
+				{ label: 'Start a new project', slug: 'guides/get-started/initial-setup/start-a-new-project' },
               ],
             },
           ],
@@ -64,15 +64,15 @@ export default defineConfig({
           collapsed: false,
           items: [
             {
-              label: 'Building and managing scenes',
+              label: 'Build and manage scenes',
               collapsed: true,
               items: [
-                { label: 'Scene budget guidelines', slug: 'guides/scene-development/building-and-managing-scenes/scene-budget-guidelines' },
+                { label: 'Scene budget guidelines (WIP)', slug: 'guides/scene-development/building-and-managing-scenes/scene-budget-guidelines' },
                 { label: 'Add scenes to your project', slug: 'guides/scene-development/building-and-managing-scenes/add-scenes-to-your-project' },
               ],
             },
             {
-              label: 'Working with assets',
+              label: 'Work with assets',
               collapsed: true,
               items: [
                 { label: 'Asset types', slug: 'guides/scene-development/working-with-assets/asset-types' },
@@ -81,7 +81,6 @@ export default defineConfig({
                 { label: 'Optimize assets for performance', slug: 'guides/scene-development/working-with-assets/optimize-assets-for-performance' },
               ],
             },
-            { label: 'Entities and components', slug: 'guides/scene-development/entities-and-components' },
           ],
         },
         {

--- a/src/content/docs/guides/scene-development/building-and-managing-scenes/add-scenes-to-your-project.md
+++ b/src/content/docs/guides/scene-development/building-and-managing-scenes/add-scenes-to-your-project.md
@@ -1,6 +1,72 @@
 ---
 title: Add scenes to your project
-description: A guide in my new Starlight docs site.
+description: Learn to view and create scene in your project.
 ---
 
-Lorem ipsum.
+This guide walks you through viewing and creating a scene in your project.
+
+## About scenes
+
+In iR Engine, a project can contain multiple scenes, allowing you to meet a range of project needs within a single domain. A scene is an entity hierarchy that holds all the entities, assets, and components that make up the parts of your project.
+
+## Access the scenes collection
+
+You can access your project’s scenes in the iR Engine in two ways: from the **Console**, and from the **Studio**. The following sections describe each option.
+
+### View scenes from the Console
+
+The My Projects page in the Studio provides an overview of all your projects. Each project displays the scene(s) associated with it in a thumbnail. After opening a scene, you can update a scene thumbnail by updating the **scene preview camera** inside the Studio.
+
+> Insert screenshot
+> 
+
+Figure 1. Scenes view from a project in the Console.
+
+### View scenes from the Studio
+
+Locate the **Scenes** tab at the bottom left of the browser. This tab opens a panel showing the collection of existing scenes associated with the project you are currently working on.
+
+> Insert screenshot
+> 
+
+Figure 2. View of your project Scenes tab.
+
+## Create a scene
+
+Follow these steps to add a new scene to your project:
+
+### Create scenes from the Console
+
+1. Go to the **My Projects** page from the left panel.
+2. Find the project where you want to create the scene.
+3. Click **Add new scene**. This action creates your scene
+4. Click the scene you wish to enter to open the Studio.
+
+> Insert screenshot
+> 
+
+Figure 3. **Add new scene** option within your project’s scene collection.
+
+### Create scenes from the Studio
+
+1. Ensure the **Scenes** tab is active in the lower panel of the Studio. This tab displays all available scenes in your project.
+
+    > Insert screenshot
+    > 
+
+    Figure 4. **Scenes** tab active in the Studio.
+
+2. Click the **Add Scene** button on the right side of the panel. This creates a new scene in your project.
+
+    > Insert screenshot
+    > 
+
+    Figure 4. **Add Scene** button location within the **Scenes** tab.
+
+3. Optionally, you can rename your scene using the three-dot menu (**…**) on the scene thumbnail for better organization.
+
+After creating your scene, it automatically becomes active, and you can start building your experience.
+
+## Next steps
+
+Now that you have created your first scene in your project, you can proceed to (load assets into your scene)[link] to build your experience.

--- a/src/content/docs/guides/scene-development/building-and-managing-scenes/scene-budget-guidelines.md
+++ b/src/content/docs/guides/scene-development/building-and-managing-scenes/scene-budget-guidelines.md
@@ -3,4 +3,6 @@ title: Scene budget guidelines
 description: A guide in my new Starlight docs site.
 ---
 
-Lorem ipsum.
+:::caution[Page under construction]
+This page is currently under construction.
+:::

--- a/src/content/docs/guides/scene-development/entities-and-components.md
+++ b/src/content/docs/guides/scene-development/entities-and-components.md
@@ -1,6 +1,0 @@
----
-title: Entities and components
-description: A guide in my new Starlight docs site.
----
-
-Lorem ipsum.


### PR DESCRIPTION
Adds the "Add scenes to your project" guide and reorganizes the navigation of the section.