### PR TITLE
Scene development -> Work with assets: Guides content + placeholders for images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,8 +75,8 @@ export default defineConfig({
               label: 'Work with assets',
               collapsed: true,
               items: [
-                { label: 'Asset types', slug: 'guides/scene-development/working-with-assets/asset-types' },
-                { label: 'Import assets and files', slug: 'guides/scene-development/working-with-assets/import-assets-and-files' },
+                { label: 'Asset types guide', slug: 'guides/scene-development/working-with-assets/asset-types-guide' },
+                { label: 'Import files and assets', slug: 'guides/scene-development/working-with-assets/import-files-and-assets' },
                 { label: 'Load assets into scenes', slug: 'guides/scene-development/working-with-assets/load-assets-into-scenes' },
                 { label: 'Optimize assets for performance', slug: 'guides/scene-development/working-with-assets/optimize-assets-for-performance' },
               ],

--- a/src/content/docs/guides/scene-development/working-with-assets/asset-types-guide.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/asset-types-guide.md
@@ -1,0 +1,132 @@
+---
+title: Asset types guide
+description: Learn about the types of pre-built assets available in the iR Engine.
+---
+
+This document provides a comprehensive overview of the asset categories and subcategories available in the **Assets** panel within the Studio. Learn to efficiently locate and use assets to create your virtual experience.
+
+## About assets
+
+The Studio offers a wide variety of pre-built assets to streamline your workflow. You can see these assets in the **Assets panel** within the tab with the same name. The following sections explain the asset categories and the types of assets they contain.
+
+> Insert screenshot
+> 
+
+Figure 1. The **Assets** panel showcasing **Prop** models.
+
+### Prefabs
+
+**Prefabs** are groupings of commonly used components prepackaged into ready-to-use or edit titles. You can configure your own prefabs by building and saving collections of components on an entity. Prefabs assets include:
+
+- **UI:** User interface elements like buttons, menus, and text boxes.
+- **Default Prefabs:** An Entity with a Model Component, Animation Component, and Environment Map
+- **Text:** Editable text objects for titles, labels, and informational displays.
+- **Lighting:** Pre-configured light sources you can drag and drop into your scene.
+- **Colliders:** Box, Sphere, Cylinder & Mesh Colliders
+
+### Templates
+
+**Templates** are pre-designed starter scenes to jumpstart your project. These include:
+
+- **Backdrop:** Background elements to establish a scene's setting.
+- **Stage:** Pre-built environments themed for specific purposes like:
+  - **E-Commerce**: Product displays and interactive shopping experiences.
+  - **Art Show**: Galleries to showcase virtual artwork.
+  - **Performance**: Stage arrangements for virtual events (needs more info)
+
+### Models
+
+3D **models** that populate your scenes. Their subcategories include:
+
+- **Characters:**
+  - **NPC (Non-player character):** Animated characters for your virtual world.
+- **Architectural:** Structural elements for building environments:
+  - **Floor, Ceiling, Wall:** Basic building blocks for constructing spaces.
+- **Basic Shapes:** Simple geometric shapes for versatile use cases:
+  - **Artistic/Fractal:** Non-traditional shapes for creative design.
+  - **Primitive:** Platonic solids (cube, sphere, etc.) and other fundamental shapes.
+  - **Kit:** Collections of objects themed for specific styles.
+- **Prop:** Smaller objects to enhance scene detail and interactivity:
+  - **Furniture:** Chairs, tables, and other furnishings.
+  - **Showcase:** Display units for products or exhibits.
+- **Terrain:** Landscapes for creating outdoor environments.
+
+### Materials
+
+Pre-configured surface properties (shaders) for your models. These include:
+
+- **Standard:** Materials for common materials like plastic, glass, and metal.
+- **Advanced:** Materials with more complex properties like animation.
+
+### Images: Textures
+
+**Textures** represent two-dimensional visual elements that you can apply to 3D models for surface detail. Besides controlling effects like metallic and reflective properties, they also include:
+
+- **Diffuse:** Define the base color information for a 3D model's surface.
+- **Normal maps:** Define surface details like bumps, wrinkles, scratches, and more.
+- **Metalness:** Defines how reflective the surface is.
+- **Roughness:** Defines how rough or smooth a surface is.
+- **Occlusion:** Simulate depth and shadows.
+- **ORM:** Embedded Combination of an **Occlusion**, **Roughness**, and **Metalness Map** (recommended for the web)
+
+**Other image types:**
+
+- **Background:** Images used as backdrops for scenes.
+- **Sprite:** Two-dimensional images used for visual effects or UI elements that can be played through.
+
+### Light
+
+Pre-configured light sources for illuminating your scenes. Types include:
+
+- **Spot Light**: Focused beams of light.
+- **Area Light**: Emissive surfaces that bathe a scene in light.
+- **Point Light**: Lights that radiate from a single point.
+- **3 Point Light**: A pre-configured setup with three lights for realistic lighting.
+
+### Video
+
+Video clips for use in your virtual experiences.
+
+### Audio
+
+Sound effects and music to enhance immersion:
+
+- **Music:** Background music to set the mood.
+- **Sound FX:** Sound effects for actions and events within your scene.
+
+### Particle
+
+Visual effects to apply to your projects; they include smoke, fire, sparkles, and more.
+
+### Skyboxes
+
+Pre-configured spherical environments, with hemisphere and directional lights, encompassing your scene, including:
+
+- **Time of Day:** Skies representing different times of day (morning, noon, evening, night).
+- **Abstract, Low Contrast, High Contrast:** Non-realistic sky options.
+
+### Post Processing
+
+Effects applied after rendering to alter the overall look of your scene. These include:
+
+- **Fog:** Adds a foggy atmosphere.
+- **Cinematic:** Applies a film-like aesthetic with effects like sepia, black and white, or cell shading with color adjustments.
+
+### Agents
+
+Large language model-enabled (LLM) 3D models with advanced functionality aimed to enhance your users' experience.
+
+### Genre
+
+The Studio offers a wide variety of assets designed to suit a broad range of thematic styles, from realistic environments like offices and nature scenes to landscapes and historical settings. Explore the asset library to discover elements that match the vision for your virtual experience.
+
+## User library and favorites
+
+For optimal asset management, the Assets panel offers these additional options:
+
+- **User Library:** Organize and store your own custom assets for easy access across projects.
+- **Favorites:** Mark frequently used assets for quick retrieval within your projects.
+
+## Find assets in the Studio
+
+Use the Studio's search and filter functionalities to find specific assets by category, name, or genre. With a clear understanding of asset organization within the Studio, you can effectively locate the building blocks you need to bring your virtual world to life.

--- a/src/content/docs/guides/scene-development/working-with-assets/asset-types.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/asset-types.md
@@ -1,6 +1,0 @@
----
-title: Asset types
-description: A guide in my new Starlight docs site.
----
-
-Lorem ipsum.

--- a/src/content/docs/guides/scene-development/working-with-assets/import-assets-and-files.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/import-assets-and-files.md
@@ -1,6 +1,0 @@
----
-title: Import assets and files
-description: A guide in my new Starlight docs site.
----
-
-Lorem ipsum.

--- a/src/content/docs/guides/scene-development/working-with-assets/import-files-and-assets.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/import-files-and-assets.md
@@ -1,0 +1,78 @@
+---
+title: Import files and assets
+description: Learn to import files and assets into your project.
+---
+
+Learn to import files and assets into your project so you can use them in your scenes.
+
+## Formats supported and size limit
+
+For optimal performance within the iR Engine, consider these guidelines when importing assets:
+
+### List of supported formats
+
+Supported file formats include:
+
+- **3D model formats:** `.glb` and `.gltf` (with `.bin` and `.ktx2`)
+  - The Studio does not support `.fbx`
+- **Image formats:** `.png`, `.tiff`, `.jpg`, `.gif` `.jpeg`, and `.ktx2`
+- **Audio formats:** `.mp3`, `.mpeg`, `.m4a`, `.wav`
+- **Video formats:** `.mp4`, `.mkv`, `.avi`
+
+### Recommended file size
+
+For optimal performance, *use files under 300 MB*. Files over this size affect the performance of your experience both when building it in the Studio and when users access it on the web.
+
+## Import files into your project
+
+Import assets into your scene via the **Files tab.** To do this, you can drag and drop or use the **Upload Files** and **Upload Folder** buttons.
+
+> Insert screenshot
+> 
+
+Figure 1. **Files** tab displaying file upload options and current project files.
+
+These actions place the file into your folder within the **Files** tab and make it available in the **Assets** tab as well.
+
+If you drag and drop your files, you can place them directly in the **Files** **tab**, the **Viewport**, or the **Hierarchy**. These options provide their own benefits; see the following sections to know more.
+
+:::danger
+
+Do not upload assets using the **Assets** tab or the **Hamburger** menu (☰). The Assets panel is being reworked and will provide an improved experience in future releases.
+
+:::
+
+### Importing files directly into the Viewport
+
+To upload files directly into your scene, you can drag and drop them into a location in the Viewport. Doing this also loads them into your scene **Hierarchy**. You can view imported assets in the assets folder of the **Files** Tab.
+
+### Importing files directly into the Hierarchy
+
+To upload files directly into your scene, you can drag and drop them into the **Hierarchy**. Doing this also loads them into the **Viewport** at (0,0,0). You can view imported assets in the assets folder of the **Files** Tab.
+
+## Specific format importing guides
+
+While the iR Engine supports a variety of formats, here are some additional guidelines for specific types:
+
+### Importing glTF files
+
+To import a complete glTF model that consists of multiple files, you must first combine all associated files (textures, materials, etc.) into a single folder on your device.
+
+**To upload your folder**:
+
+1. Navigate to the **Files** tab in the Studio.
+2. Click the **Upload Folder** (insert-screenshot) button.
+3. Select the folder containing all your glTF model files for upload.
+
+:::note[Uploading folders]
+The iR Engine does not support uploading folders using single file upload methods. Always use the **Upload Folder** button in the **Files** tab to import multiple files belonging to a single asset, like in the case of gLTF files.
+:::
+
+> Insert screenshot
+> 
+
+Figure 2. **Upload Folder** button location in the **Files** tab.
+
+## Next steps
+
+Now that your files are ready to use in your project, you can proceed to [load assets into your scenes](link) to begin building your experience.

--- a/src/content/docs/guides/scene-development/working-with-assets/load-assets-into-scenes.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/load-assets-into-scenes.md
@@ -1,6 +1,91 @@
 ---
 title: Load assets into scenes
-description: A guide in my new Starlight docs site.
+description: Learn to load assets into scenes to build your experience.
 ---
 
-Lorem ipsum.
+Learn to load assets into your scenes within the iR Engine Studio to enhance your projects.
+
+## Access the Assets Library
+
+The **Assets Library** is your central hub for all available assets. It is located inside the **Assets tab** and it includes both preloaded assets and allows you to upload your own. To access the library from the Studio:
+
+1. Click on the **Assets** tab located in the bottom left panel.
+2. Browse through categories such as **Models**, **Textures**, **Lighting**, and more. Use the search bar to quickly find specific assets.
+
+> Insert screenshot
+> 
+
+Figure 1. **Assets** library showcasing a prop model.
+
+Additionally, you can access all project-related files you have added to your project in the **Files** tab.
+
+:::tip[Learn about asset categories]
+For detailed information on Asset categories and types of assets, refer to the [Asset types guide](link).
+:::
+
+## Loading assets into your scene
+
+To load assets into your scene from the **Assets** library or the **Files** tab, two methods exist:
+
+- **Method 1:** Load them into the Hierarchy panel.
+
+- **Method 2:** Load them directly into the Viewport.
+
+The following sections contain details for both options.
+
+### Method 1: Load assets into the Hierarchy panel
+
+To load assets into your scene via the **Hierarchy** panel, follow these steps:
+
+1. In the **Files** or **Assets** tab, locate the asset you want to use.
+2. Drag the asset into the **Hierarchy** panel.
+3. Release the asset at the desired location within the hierarchy.
+
+> Insert screenshot
+> 
+
+Figure 2. An asset loaded into the **Hierarchy**.
+
+### Method 2: Load assets directly into the Viewport
+
+For a more visual placement, you can load assets directly into the **Viewport**:
+
+1. In the **Files** or **Assets** tab, locate the asset you want to use.
+2. Drag the asset into the **Viewport** at the desired location.
+3. Adjust the placement as needed by dragging the asset within the viewport.
+
+> Insert screenshot
+> 
+
+Figure 3. An asset loaded into the Viewport.
+
+## What happens next
+
+After placing your asset into either the **Hierarchy** or the **Viewport**, the Studio performs the following actions:
+
+1. It creates a new entity in the **Hierarchy** panel for your asset.
+2. It places your new entity at the bottom of the **Hierarchy** by default unless you add your asset to another entity.
+
+:::note[What are entities?]
+Think of entities as containers within your scene. Each entity holds a collection of assets and acts as a building block for your project.
+:::
+
+## Organize your entities
+
+You can rearrange this entity within the **Hierarchy** to suit your scene structure. Organize entities by nesting them within other entities for better management.
+
+> Insert screenshot
+> 
+
+Figure 4. Entities organized hierarchically within a parent entity.
+
+## Additional tips
+
+When loading assets and creating entities into your scene, follow these tips:
+
+- **Use descriptive names**: Organize your project with clear and descriptive entity and material names.
+- **Experiment with placement**: Adjust assets using the transform tools and hotkeys in the Viewport to achieve your desired layout.
+
+## Next steps
+
+Now that you have placed assets within your scene, you can proceed to add components to your entities and configure their properties. To know more about this process, visit the [Properties panel](link) guide.

--- a/src/content/docs/guides/scene-development/working-with-assets/optimize-assets-for-performance.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/optimize-assets-for-performance.md
@@ -1,6 +1,84 @@
 ---
 title: Optimize assets for performance
-description: A guide in my new Starlight docs site.
+description: Optimize your assets to increase performance
 ---
 
-Lorem ipsum.
+Learn to optimize your assets to use within your iR Engine projects and ensure high performance for your creations across devices.
+
+## General guidelines
+
+Because the iR Engine is a WebXR platform that works on a wide range of devices, from high-end PCs to mobile phones, you must optimize your assets similarly to how you would for a mobile game. These guidelines include information about pre-import optimization and optimization within the engine.
+
+## Pre-import optimization
+
+The optimization process starts *before* you bring your assets into the iR Engine. Here's how to optimize your 3D models for the best performance:
+
+### Minimize vertex count
+
+Reducing the vertex count is crucial for performance.
+
+- **Aim for a low polygon count**: Although our engine can handle higher polygon limits, an asset shouldn't exceed 200,000 polygons, and you should consider the total polycount of your scene after adding all your assets.
+- **Use decimation tools**: Reduce the number of polygons in your mesh without sacrificing visual quality.
+- **Maintain a uniform topology**: Ensure a consistent mesh structure for better in-engine decimation.
+
+### Minimize material count
+
+Reuse and share materials whenever possible.
+
+- **Limit materials**: Ideally, an asset should have just one material per blend model; For example, one for opaque objects and one for transparent objects.
+
+### Minimize texture count
+
+Combining multiple textures helps reduce the overall texture count.
+
+- **Use trim sheets**: Consolidate textures to optimize your models.
+  - **Blender tutorial**: [Trim sheet tutorial](https://www.youtube.com/watch?v=1M-GNe_pB9M)
+  - **Substance Painter tutorial**: [Trim sheet tutorial](https://m.youtube.com/watch?v=QoVWM-IKmFw)
+
+### Additional tips
+
+Further steps you can take to optimize your models include:
+
+- **Combine meshes**: Merge meshes that share the same material.
+- **Instance repeating geometry**: Reuse geometry to reduce the number of unique meshes.
+
+## In-engine optimization
+
+Once imported, IR Engine provides further tools to optimize your assets for web delivery. This optimization pipeline leverages the [GLTF Transform NodeJS package](https://gltf-transform.dev/).
+
+**The engine performs various actions, including**:
+
+- **Compressing images**: Convert images to KTX2 format.
+- **Running mesh compression**: Use Meshoptimizer and DRACO for efficient mesh compression.
+- **Deduplicating materials**: Eliminate duplicate materials to streamline the asset.
+- **Merging meshes**: Combine multiple meshes into a single entity.
+- **Performing additional decimation**: Further reduce mesh complexity if needed.
+
+The resulting GLTF file is fully optimized and ready for use in your IR Engine project. Here are the three ways to optimize assets within the engine:
+
+### Model transform panel (recommended)
+
+This is the preferred method for in-engine optimization.
+
+**Here's how to use it**:
+
+1. **Open a scene**: Open any scene in the studio.
+2. **Add your asset to your scene**: Drag and drop your model file into the scene from the **File Browser** or **Assets Panel**.
+3. **Select your model in the Hierarchy**: Ensure you select your entity in the **Hierarchy** and find the **Model component** in the **Properties** panel.
+4. **Open Model Transform options**: Expand the **Model** component and find **Model Transform**. Select this option to view its compression settings.
+5. **Optimize the model**: Adjust your compression settings and click the **Optimize** button when finished. This creates a new, optimized model file with the -transformed suffix. Use this optimized file instead of the original.
+
+### Compression panel
+
+This panel offers a more advanced interface for compression.
+
+**Here's a step-by-step guide**:
+
+1. **Locate the model file**: Find the model file you want to compress in the **File Browser**.
+2. **Open the compression panel**: Right-click the file and select **Compress** to open the compression panel.
+3. **Optimize the file**: After adjusting your compression settings, click "**Optimize**" to complete the process.
+4. **Use the optimized file**: Use the new file instead of the original, which includes new files and an LOD prefab with the integrated-prefab suffix.
+
+### LOD on import
+
+You can also configure IR Engine to generate LODs for every imported .gltf asset automatically. Enable and adjust this option within the **Import Settings** option inside the hamburger menu (**☰**) on the top left corner of the Studio.


### PR DESCRIPTION
Adds the complete guides for "Work with assets" inside the "Scene development" section of the site.