### PR TITLE
New: `images` directories in sections and image label fixes

### DIFF
--- a/src/content/docs/guides/get-started/initial-setup/sign-up-and-login.md
+++ b/src/content/docs/guides/get-started/initial-setup/sign-up-and-login.md
@@ -30,7 +30,7 @@ Follow these steps to create an iR Engine account:
     > Insert screenshot
     >
 
-    Figure 2. Configuring and **Organization** and **Sub Domain**.
+    Figure 2. Defining your **Organization** and **Sub Domain**.
 
     :::note
 

--- a/src/content/docs/guides/get-started/ir-engine-studio/studio-interface/file-browser-panel.md
+++ b/src/content/docs/guides/get-started/ir-engine-studio/studio-interface/file-browser-panel.md
@@ -10,14 +10,14 @@ You can access the engine’s file browser through the **Files** tab:
 > Insert screenshot
 > 
 
-Figure 1.
+Figure 1. Location of the File browser panel.
 
 Files you upload appear inside the `assets` folder.
 
 > Insert screenshot
 > 
 
-Figure 2.
+Figure 2. View of the assets folder.
 
 :::note
 Because the **Files** tab contains crucial system files to run your engine, all the files outside of assets  and public folders are read-only and cannot be modified.
@@ -30,7 +30,7 @@ Assets inside the **File Browser** and **Assets Panel** have icons to provide a 
 > Insert screenshot
 > 
 
-Figure 3.  Files within a project and their preview.
+Figure 3.  Files within a project and their thumbnail preview.
 
 ## Exploring the file browser's options
 

--- a/src/content/docs/guides/get-started/ir-engine-studio/studio-interface/properties-panel.md
+++ b/src/content/docs/guides/get-started/ir-engine-studio/studio-interface/properties-panel.md
@@ -16,7 +16,7 @@ Figure 1. Location of the Properties panel.
 
 From the **Properties** panel, after selecting an entity, you can perform the following actions:
 
-### **View components**
+### View components
 
 The **Properties** panel lists all components attached to the selected entity.
 
@@ -25,7 +25,7 @@ The **Properties** panel lists all components attached to the selected entity.
 
 Figure 2. Default components of the selected entity.
 
-### **Edit properties**
+### Edit properties
 
 Modify the properties of each component directly in the panel.
 
@@ -34,7 +34,7 @@ Modify the properties of each component directly in the panel.
 
 Figure 3. Properties of the **Transform** and **Video** components of an entity.
 
-### **Add new components**
+### Add new components
 
 Use the **Add Component** option to add new components to the selected entity.
 

--- a/src/content/docs/guides/publishing/publish-your-projects.md
+++ b/src/content/docs/guides/publishing/publish-your-projects.md
@@ -53,6 +53,11 @@ When creating a Location, you can configure its settings. Here’s a breakdown o
   - **Audio Enabled**: Users can share audio within the Location.
   - **Screen Sharing Enabled**: Users can share their screens within the Location.
 
+> Insert screenshot
+> 
+
+Figure 3. Create Location modal screen.
+
 ## Additional tips
 
 Here are some additional tips to ensure a smooth publishing process:

--- a/src/content/docs/guides/scene-development/building-and-managing-scenes/add-scenes-to-your-project.md
+++ b/src/content/docs/guides/scene-development/building-and-managing-scenes/add-scenes-to-your-project.md
@@ -61,7 +61,7 @@ Figure 3. **Add new scene** option within your project’s scene collection.
     > Insert screenshot
     > 
 
-    Figure 4. **Add Scene** button location within the **Scenes** tab.
+    Figure 5. **Add Scene** button location within the **Scenes** tab.
 
 3. Optionally, you can rename your scene using the three-dot menu (**…**) on the scene thumbnail for better organization.
 

--- a/src/content/docs/guides/scene-development/working-with-assets/load-assets-into-scenes.md
+++ b/src/content/docs/guides/scene-development/working-with-assets/load-assets-into-scenes.md
@@ -57,7 +57,7 @@ For a more visual placement, you can load assets directly into the **Viewport**:
 > Insert screenshot
 > 
 
-Figure 3. An asset loaded into the Viewport.
+Figure 3. An asset loaded into the **Viewport**.
 
 ## What happens next
 

--- a/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/add-videos-to-your-store.md
+++ b/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/add-videos-to-your-store.md
@@ -8,7 +8,7 @@ Videos can significantly enhance the interactivity and engagement of your virtua
 > Insert screenshot
 > 
 
-Figure 1.
+Figure 1. Example of a video on a screen.
 
 ## Step 1. Create video entities for your screens
 
@@ -22,7 +22,7 @@ To play videos in your store, you first need to create entities that will act as
     > Insert screenshot
     > 
 
-    Figure 2.
+    Figure 2. Adding a **Video** entity.
 
 3. **Activate the video entity:** Ensure your new video entity is selected in the **Hierarchy** panel so its components are displayed in the **Properties** panel.
 
@@ -38,14 +38,14 @@ After creating a video entity, you need to specify the video source that will pl
     > Insert screenshot
     > 
 
-    Figure 3.
+    Figure 3. **Media** component properties.
 
 3. **Add a source path:** Click the **+** (plus) sign in the **Source Paths** section to add a new source path field. This field will be named **Path 1** automatically.
 
     > Insert screenshot
     > 
 
-    Figure 4.
+    Figure 4. **Source Path** field for your video file.
 
 4. **Locate your video file:** Open the **Files** tab to find the video source you want to add to your entity.
 5. **Add the video file to the source path:** Drag and drop your video file from the **Files** tab into the text field of the newly created source path. This action links the video file to the video entity.
@@ -53,14 +53,14 @@ After creating a video entity, you need to specify the video source that will pl
     > Insert screenshot
     > 
 
-    Figure 5.
+    Figure 5. Video file linked to **Source Path**.
 
     Alternatively, you can right-click your file in the **Files** tab and copy its URL, then paste it into the source path field.
 
     > Insert screenshot
     > 
 
-    Figure 6.
+    Figure 6. **Copy URL** options on a file.
 
 ## Step 3. Configure video settings
 

--- a/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/build-your-store-templates-and-ambiance.md
+++ b/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/build-your-store-templates-and-ambiance.md
@@ -30,7 +30,7 @@ If you cannot find templates that resemble a modern store to use in this tutoria
     > Insert screenshot
     > 
 
-    Figure 1.
+    Figure 1. Location of the **Assets** tab.
 
 2. **Find the model category:** In the list of assets on the left, locate and expand the **Model** category.
 3. **Select the templates category:** Click **Templates** to view the available model templates.
@@ -38,21 +38,21 @@ If you cannot find templates that resemble a modern store to use in this tutoria
     > Insert screenshot
     > 
 
-    Figure 2.
+    Figure 2. **Model** category expanded within the assets panel.
 
 4. **Choose the appropriate template:** For this tutorial, use the `NMS_HubsLM_Template_large.glb` model or any other that resembles a modern retail store. These type of files include models for your shopping experience with fully set light maps.
 
     > Insert screenshot
     > 
 
-    Figure 3.
+    Figure 3. Templates available to youse in your project.
 
 5. **Add the template to your scene:** Drag and drop your store file from the **Assets** tab into the bottom of the **Hierarchy** panel located at the top right of the Studio interface.
 
     > Insert screenshot
     > 
 
-    Figure 4.
+    Figure 4. **Template** showing as an entity at the bottom of the **Hierarchy**.
 
     This action creates a **New Object** with all your model’s elements. You can expand the model to see its objects, including **walls**, **flooring**, **box colliders**, **windows**, **display cases**, **ceiling**, and also the **lighting settings** of your store.
 
@@ -78,14 +78,14 @@ A skybox is a spherical environment that surrounds your scene, providing lightin
    > Insert screenshot
    > 
 
-   Figure 5.
+    Figure 5. **Properties** of the **EE_skybox** entity.
 
 3. Expand the **Skybox** component and set the **Sky Type** to **Equirectangular** from the dropdown menu.
 
     > Insert screenshot
     > 
 
-    Figure 6.
+    Figure 6. **Skybox** component showing **Sky Type** settings.
 
 ### 2. Assign a skybox image
 
@@ -95,7 +95,7 @@ A skybox is a spherical environment that surrounds your scene, providing lightin
      > Insert screenshot
      > 
 
-     Figure 7.
+     Figure 7. Assets available for **Skybox** files.
 
  3. Drag and drop the `desert_daytime_04.png` file into the **Texture** field in the **Properties** panel, ensuring the **EE_skybox** entity is selected.
 

--- a/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/configure-shopify-plugin.md
+++ b/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/configure-shopify-plugin.md
@@ -18,7 +18,7 @@ To load your Shopify products into the iR Engine, enable and configure the Shopi
     > Insert screenshot
     > 
 
-    Figure 1.
+    Figure 1. Location of the **Configure** button in Console.
 
 3. **Enable the Shopify plugin:**
     - In the project settings, find the **Plugins** section.
@@ -27,7 +27,7 @@ To load your Shopify products into the iR Engine, enable and configure the Shopi
     > Insert screenshot
     > 
 
-    Figure 2.
+    Figure 2. Shopify integration toggle enabled.
 
 4. **Enter your Storefront Access Token:**
     - In the Shopify integration settings, locate the **Storefront Access Token** text field.

--- a/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/load-and-place-shopify-products.md
+++ b/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/load-and-place-shopify-products.md
@@ -17,14 +17,14 @@ Entities are fundamental building blocks in the iR Engine. You will create an em
     > Insert screenshot
     > 
 
-    Figure 1.
+    Figure 1. **Empty** entity category in the Hierarchy.
 
 3. **Make the entity active:** Ensure your new entity is selected in the **Hierarchy** panel so its components are displayed in the **Properties** panel.
 
     > Insert screenshot
     > 
 
-    Figure 2.
+    Figure 2. Properties of your new entity.
 
 ## Step 2. Attach an Ecommerce Product component to your entity
 
@@ -48,21 +48,21 @@ With the Ecommerce Product component in place, you can now load your product int
     > Insert screenshot
     > 
 
-    Figure 3.
+    Figure 3. **Ecommerce Product** component and its settings.
 
 2. **Choose a product:** In the **Product** dropdown menu, select the product you want to load. This action configures the component to display the selected product.
 
     > Insert screenshot
     > 
 
-    Figure 4.
+    Figure 4. List of Shopify products.
 
 3. **Verify the product loads:** The entity now populates with the model of the selected product. You can see the product appear in the Viewport.
 
     > Insert screenshot
     > 
 
-    Figure 5.
+    Figure 5. Product loaded into the Viewport.
 
 :::note[You can’t find your Shopify product?]
 If the list of products does not show any of your Shopify products, ensure your store is correctly set up. Revisit the [Configure the Shopify plugin](link) guide to confirm proper integration.
@@ -92,7 +92,7 @@ When you load a Shopify product into your scene, clicking on it in the Viewport 
 > Insert screenshot
 > 
 
-Figure 6.
+Figure 6. Product ecommerce details view.
 
 ## Next steps: Adding videos to your store
 

--- a/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/publish-your-store.md
+++ b/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/publish-your-store.md
@@ -26,7 +26,7 @@ Before publishing, ensure that your scene is complete and all elements are prope
     > Insert screenshot
     > 
 
-    Figure 1.
+    Figure 1. Location of the **Publish** button.
 
 2. **Configure virtual space details:**
     1. Click the **Publish** button to open the publishing menu.
@@ -34,7 +34,7 @@ Before publishing, ensure that your scene is complete and all elements are prope
         > Insert screenshot
         > 
 
-        Figure 2.
+        Figure 2. Configuring your **Location**'s settings.
 
     2. Fill in the necessary details for your virtual space; define maximum users, along with video, audio, and screen sharing options, and choose the type of location:
         - **Private**: Only users with specific access can enter.
@@ -48,7 +48,7 @@ Before publishing, ensure that your scene is complete and all elements are prope
         > Insert screenshot
         > 
 
-        Figure 3.
+        Figure 3. URL of your newly published **Location**.
 
 ## Step 3. Access and explore your store
 

--- a/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/set-up-spatial-audio.md
+++ b/src/content/docs/guides/tutorials-and-examples/build-an-ecommerce-store/set-up-spatial-audio.md
@@ -19,7 +19,7 @@ First, load an audio file and attach it to an entity in your scene.
 
     > Insert screenshot
     > 
-    Figure 1.
+    Figure 1. Properties of your selected entity.
 
 2. **Expand the Media component:** In the **Properties** panel, expand the **Media** component to view its options.
 3. **Add a source path:** Click the **+** (plus) sign in the **Source Paths** section to create a new field named **Path 1**.
@@ -27,7 +27,7 @@ First, load an audio file and attach it to an entity in your scene.
     > Insert screenshot
     > 
 
-    Figure 2.
+    Figure 2. **Source Path** field for your audio file.
 
 4. **Locate your audio file:** Open the **Files** tab to find the audio source you want to use.
 5. **Attach the audio file:** Drag and drop your audio file from the **Files** tab into the source path text field. This action links the audio file to the entity.
@@ -35,7 +35,7 @@ First, load an audio file and attach it to an entity in your scene.
     > Insert screenshot
     > 
 
-    Figure 3.
+    Figure 3. Audio file linked to **Source Path**.
 
     Alternatively, right-click the file in the **Files** tab, copy its URL, and paste it into the source path field.
 
@@ -52,7 +52,7 @@ Once the audio file is attached, add a positional audio component to your entity
     > Insert screenshot
     > 
 
-    Figure 4.
+    Figure 4. Adding an **Audio** component.
 
     Alternatively, find it inside the **Files** component category.
 
@@ -61,7 +61,7 @@ Once the audio file is attached, add a positional audio component to your entity
     > Insert screenshot
     > 
 
-    Figure 5.
+    Figure 5. **Positional Audio** component added to your entity.
 
 ## Step 3. Configure the positional audio settings
 
@@ -74,7 +74,7 @@ After adding the positional audio component, configure its settings to define ho
     > Insert screenshot
     > 
 
-    Figure 6.
+    Figure 6. Settings for **Positional Audio**.
 
 2. **Adjust audio settings:** Configure settings such as the **distance model**, **rolloff factor**, **reference distance**, **audio cone angles**, and **max distance**. 
 


### PR DESCRIPTION
This PR adds missing image description labels and creates `images` directory for each section. This allows us to keep images organized.