### PR TITLE
New: Release notes page placeholder and template

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -121,6 +121,10 @@ export default defineConfig({
             },
           ],
         },
+        {
+          label: 'Release notes',
+          slug: 'release-notes',
+        },
       ],
       components: {
         // Use the custom PageFrame component for layout

--- a/src/content/docs/release-notes.mdx
+++ b/src/content/docs/release-notes.mdx
@@ -1,0 +1,37 @@
+---
+title: Release notes
+description: Discover platform release improvements and bug fixes.
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
+---
+
+Discover the latest platform improvements and bug fixes for the iR Engine.
+
+## 1.0: September 2024
+
+**Release date:** [Date in `YYYY-MM-DD` format]
+
+### Summary
+
+This inaugural release of the iR Engine lays the foundation for building and managing virtual experiences with a focus on stability, core functionality, and ease of use.
+
+### New features
+
+- [List new features here with brief descriptions]
+
+### Improvements
+
+- [List improvements to existing features here with brief descriptions]
+
+### Fixes
+
+- [List bug fixes here with brief descriptions]
+
+### Known issues
+
+- [List any known issues that users may encounter]
+
+### Additional notes
+
+- [Include any additional relevant information here, such as upgrade instructions or compatibility considerations]


### PR DESCRIPTION
Adds the initial placeholder to include release notes to communicate updates on the iR Engine.