### PR TITLE
Fix: Initial release version in release notes document

### DIFF
--- a/src/content/docs/release-notes.mdx
+++ b/src/content/docs/release-notes.mdx
@@ -8,9 +8,9 @@ tableOfContents:
 
 Discover the latest platform improvements and bug fixes for the iR Engine.
 
-## v0.8 - September 2024
+## v0.7 - August 2024
 
-> **Release date:** 2024/08/09
+> **Release date:** 2024/08/08
 
 ### Summary
 


### PR DESCRIPTION
Updating the release version and date for the initial deployment of the engine.